### PR TITLE
Set custom options using ES_JAVS_OPTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM elasticsearch:1
 
 ENV TZ Europe/Paris
-
-RUN echo "script.disable_dynamic: false" >> /usr/share/elasticsearch/config/elasticsearch.yml
+ENV ES_JAVA_OPTS -Des.script.disable_dynamic=false
 
 EXPOSE 9200 9300


### PR DESCRIPTION
Some environments, e.g. the Elasticsearch plugin for Dokku, mount a host
directory over the configuration directory, making the customizations
ineffective. ES_JAVA_OPTS always overrides options from a configuration
file.