### PR TITLE
Docker compatibility with OpenShift

### DIFF
--- a/fix-permissions
+++ b/fix-permissions
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Fix permissions on the given directory to allow group read/write of
+# regular files and execute of directories.
+chown -R elasticsearch "$1"
+chgrp -R 0 "$1"
+chmod -R g+rw "$1"
+find "$1" -type d -exec chmod g+x {} +

--- a/start.sh
+++ b/start.sh
@@ -23,8 +23,7 @@ fi
 
 if [ "$1" = 'elasticsearch' ]; then
 	echo -e '\nStarting elasticsearch...'
-	chown -R elasticsearch "/usr/share/elasticsearch" && sync
-	exec gosu elasticsearch "$@"
+	exec elasticsearch "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
This PR updates the Dockerfile so that an OpenShift compatible Docker image will be created. It basically configures the image to be run as non-privileged user by setting correct file permissions and skip the use of gosu as it already will run as unprivileged user.