### PR TITLE
feat(version): Update to Elasticsearch 2.4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 env:
-  - NAME=elasticsearch TAGS="livingdocs/elasticsearch:latest livingdocs/elasticsearch:1 livingdocs/elasticsearch:1.7 livingdocs/elasticsearch:1.7.5"
+  - NAME=elasticsearch TAGS="livingdocs/elasticsearch:latest livingdocs/elasticsearch:2 livingdocs/elasticsearch:2.4 livingdocs/elasticsearch:2.4.5"
 
 script:
   - docker build -t $NAME .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ script:
   - docker build -t $NAME .
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+  - |
+    if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
       for tag in $TAGS; do
         docker tag $NAME $tag;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.4
-ENV ELASTICSEARCH_VERSION 1.7.5
+ENV ELASTICSEARCH_VERSION 2.4.5
 ENV PATH $PATH:/usr/share/elasticsearch/bin
 
 COPY fix-permissions /usr/libexec/fix-permissions
@@ -21,7 +21,7 @@ RUN \
   java -version 2>&1 && \
 
   echo ELASTICSEARCH VERSION: && \
-  elasticsearch -v && \
+  elasticsearch --version && \
 
   # cleanup
   rm -rf /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elasticsearch
 
-The elasticsearch setup we at Livingdocs currently use in development
+The Elasticsearch setup we at Livingdocs currently use in development
 
 
 ## Create a container and give it a name

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -15,4 +15,4 @@ path:
 node:
   name: ${HOSTNAME}
 
-script.disable_dynamic: false
+script.inline: on

--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,7 @@ fi
 
 if [ "$1" = 'elasticsearch' ]; then
 	echo -e '\nStarting elasticsearch...'
-	exec elasticsearch "$@"
+	exec elasticsearch
 fi
 
 exec "$@"

--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,6 @@ fi
 
 if [ "$1" = 'elasticsearch' ]; then
 	echo -e '\nStarting elasticsearch...'
-	exec elasticsearch
 fi
 
 exec "$@"


### PR DESCRIPTION
A new Elasticsearch version, as 1.7 reached its end of life.
According to the EOL table its about time to shift to 2.4 or even 5.4:
https://www.elastic.co/support/eol

This also lifts up the `latest` version to 2.4.5.